### PR TITLE
Change base image; update docker-ce

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jetbrains/teamcity-agent:2018.1.2
+FROM jetbrains/teamcity-agent:2018.2.4
 
 #  TG-Terragrunt and TF-Terraform version
 ENV TG_VERSION=v0.18.7 \
@@ -10,7 +10,7 @@ RUN curl https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py && \
     pip install jsonpickle && \
     mv /root/.local/bin/aws /bin/aws && \
     apt-get update -y && \
-    apt install software-properties-common -y && \
+    apt install software-properties-common unzip docker-ce -y && \
     apt-add-repository --yes --update ppa:ansible/ansible && \
     apt install ansible -y && \
     curl -sS -L -O https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_amd64.zip && \


### PR DESCRIPTION
Update base image (tested);
Install unzip, update docker-ce packege to the latest version - docker BuildKit support is needed (since 18.09, was 18.03, updated to 19.03).